### PR TITLE
Add employee management in meeting TUI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
 // main.rs
 
-use std::{error::Error, io::Write, path::PathBuf, time::Duration};
+use std::{error::Error, path::PathBuf, time::Duration};
 
 use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode};
-use crossterm::terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen};
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
 use meeting_cost_tracker::{load_categories, save_categories, EmployeeCategory, Meeting};
 use ratatui::backend::CrosstermBackend;
 use ratatui::layout::{Constraint, Direction, Layout};
@@ -16,6 +18,8 @@ enum Mode {
     View,
     AddCategory,
     DeleteCategory,
+    AddAttendee,
+    RemoveAttendee,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -28,11 +32,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     enable_raw_mode()?;
     let mut stdout = std::io::stdout();
-    crossterm::execute!(
-        stdout,
-        EnterAlternateScreen,
-        EnableMouseCapture
-    )?;
+    crossterm::execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
@@ -84,12 +84,27 @@ fn main() -> Result<(), Box<dyn Error>> {
                 }
                 Mode::View => {
                     let help = Paragraph::new(Line::from(vec![
-                        Span::raw("[s] Start  [t] Stop  [a] Add Category  [d] Delete Category  [q] Quit"),
+                        Span::raw("[s] Start  [t] Stop  [a] Add Category  [d] Delete Category  [e] Add Employee  [r] Remove Employee  [q] Quit"),
                     ]))
                     .block(Block::default().borders(Borders::ALL).title("Controls"));
                     f.render_widget(help, chunks[2]);
                 }
+                Mode::AddAttendee => {
+                    let input_widget = Paragraph::new(input_text.as_str())
+                        .block(Block::default().title("Enter: Title:Count").borders(Borders::ALL));
+                    f.render_widget(input_widget, chunks[2]);
+                }
+                Mode::RemoveAttendee => {
+                    let input_widget = Paragraph::new(input_text.as_str())
+                        .block(Block::default().title("Enter: Title:Count to remove").borders(Borders::ALL));
+                    f.render_widget(input_widget, chunks[2]);
+                }
             }
+
+            let lists = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+                .split(chunks[3]);
 
             let category_list: Vec<Line> = categories
                 .iter()
@@ -97,7 +112,15 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .collect();
             let list_widget = Paragraph::new(category_list)
                 .block(Block::default().borders(Borders::ALL).title("Employee Categories"));
-            f.render_widget(list_widget, chunks[3]);
+            f.render_widget(list_widget, lists[0]);
+
+            let meeting_list: Vec<Line> = meeting
+                .attendees()
+                .map(|(title, (_, count))| Line::from(Span::raw(format!("{} x {}", title, count))))
+                .collect();
+            let meeting_widget = Paragraph::new(meeting_list)
+                .block(Block::default().borders(Borders::ALL).title("Current Meeting"));
+            f.render_widget(meeting_widget, lists[1]);
         })?;
 
         let timeout = tick_rate
@@ -119,15 +142,28 @@ fn main() -> Result<(), Box<dyn Error>> {
                             input_text.clear();
                             mode = Mode::DeleteCategory;
                         }
+                        KeyCode::Char('e') => {
+                            input_text.clear();
+                            mode = Mode::AddAttendee;
+                        }
+                        KeyCode::Char('r') => {
+                            input_text.clear();
+                            mode = Mode::RemoveAttendee;
+                        }
                         _ => {}
                     },
-                    Mode::AddCategory | Mode::DeleteCategory => match key_event.code {
+                    Mode::AddCategory
+                    | Mode::DeleteCategory
+                    | Mode::AddAttendee
+                    | Mode::RemoveAttendee => match key_event.code {
                         KeyCode::Enter => {
                             match mode {
                                 Mode::AddCategory => {
                                     if let Some((title, salary_str)) = input_text.split_once(':') {
                                         if let Ok(salary) = salary_str.trim().parse::<f64>() {
-                                            if let Ok(cat) = EmployeeCategory::new(title.trim(), salary) {
+                                            if let Ok(cat) =
+                                                EmployeeCategory::new(title.trim(), salary)
+                                            {
                                                 categories.push(cat);
                                             }
                                         }
@@ -136,6 +172,25 @@ fn main() -> Result<(), Box<dyn Error>> {
                                 Mode::DeleteCategory => {
                                     let title = input_text.trim();
                                     categories.retain(|c| c.title() != title);
+                                }
+                                Mode::AddAttendee => {
+                                    if let Some((title, count_str)) = input_text.split_once(':') {
+                                        if let Ok(count) = count_str.trim().parse::<u32>() {
+                                            if let Some(cat) = categories
+                                                .iter()
+                                                .find(|c| c.title() == title.trim())
+                                            {
+                                                meeting.add_attendee(cat.clone(), count);
+                                            }
+                                        }
+                                    }
+                                }
+                                Mode::RemoveAttendee => {
+                                    if let Some((title, count_str)) = input_text.split_once(':') {
+                                        if let Ok(count) = count_str.trim().parse::<u32>() {
+                                            meeting.remove_attendee(title.trim(), count);
+                                        }
+                                    }
                                 }
                                 _ => {}
                             }

--- a/src/meeting.rs
+++ b/src/meeting.rs
@@ -26,8 +26,29 @@ impl Meeting {
 
     /// Adds `count` attendees of a given [`EmployeeCategory`] to the meeting.
     pub fn add_attendee(&mut self, category: EmployeeCategory, count: u32) {
-    let entry = self.attendees.entry(category.title().to_string()).or_insert((category.salary(), 0));
-    entry.1 += count;
+        let entry = self
+            .attendees
+            .entry(category.title().to_string())
+            .or_insert((category.salary(), 0));
+        entry.1 += count;
+    }
+
+    /// Removes up to `count` attendees of the given title from the meeting.
+    /// If the resulting count is zero, the attendee entry is removed entirely.
+    pub fn remove_attendee(&mut self, title: &str, count: u32) {
+        if let Some(entry) = self.attendees.get_mut(title) {
+            if entry.1 <= count {
+                self.attendees.remove(title);
+            } else {
+                entry.1 -= count;
+            }
+        }
+    }
+
+    /// Returns an iterator over the attendee list.
+    #[must_use]
+    pub fn attendees(&self) -> impl Iterator<Item = (&String, &(f64, u32))> {
+        self.attendees.iter()
     }
 
     /// Starts the meeting. Does nothing if already running.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -3,7 +3,7 @@ mod tests {
     use std::path::PathBuf;
     use std::time::Duration;
 
-    use meeting_cost_tracker::{EmployeeCategory, Meeting, load_categories, save_categories};
+    use meeting_cost_tracker::{load_categories, save_categories, EmployeeCategory, Meeting};
 
     #[test]
     fn test_employee_category_creation() {
@@ -41,6 +41,18 @@ mod tests {
         meeting.reset();
 
         assert_eq!(meeting.total_cost(), 0.0);
+    }
+
+    #[test]
+    fn test_add_and_remove_attendees() {
+        let cat = EmployeeCategory::new("QA", 80_000.0).unwrap();
+        let mut meeting = Meeting::new();
+        meeting.add_attendee(cat.clone(), 3);
+        assert_eq!(meeting.attendees().next().unwrap().1 .1, 3);
+        meeting.remove_attendee(cat.title(), 2);
+        assert_eq!(meeting.attendees().next().unwrap().1 .1, 1);
+        meeting.remove_attendee(cat.title(), 1);
+        assert!(meeting.attendees().next().is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- allow adding/removing attendees from a meeting
- show current meeting attendees in the TUI
- extend tests to cover attendee removal

## Testing
- `cargo test --test tests --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6872dbb02a448327bf9695b31395802f