### PR TITLE
Improve docs with professional examples

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-
 //! # Meeting Cost Tracker
 //!
 //! A library for tracking the cost of meetings in real-time, based on attendee salaries.
@@ -11,17 +10,17 @@
 //!
 //! let category = EmployeeCategory::new("Engineer", 120_000.0).unwrap();
 //! let mut meeting = Meeting::new();
-//! meeting.add_attendee(category.clone(), 3);
+//! meeting.add_attendee(&category, 3);
 //! meeting.start();
 //! std::thread::sleep(std::time::Duration::from_millis(500));
 //! meeting.stop();
 //! println!("Cost: ${:.2}", meeting.total_cost());
 //! ```
 
-mod model;
 mod meeting;
+mod model;
 mod storage;
 
-pub use model::EmployeeCategory;
 pub use meeting::Meeting;
+pub use model::EmployeeCategory;
 pub use storage::{load_categories, save_categories};

--- a/src/meeting.rs
+++ b/src/meeting.rs
@@ -14,6 +14,25 @@ pub struct Meeting {
 
 impl Meeting {
     /// Creates a new, empty [`Meeting`].
+    ///
+    /// # Arguments
+    ///
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// A new empty [`Meeting`].
+    ///
+    /// ## Example
+    /// ```
+    /// use meeting_cost_tracker::Meeting;
+    /// let meeting = Meeting::new();
+    /// assert!(!meeting.is_running());
+    /// ```
+    ///
+    /// # See Also
+    /// * [`Meeting::start`]
+    /// * [`Meeting::add_attendee`]
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -25,6 +44,26 @@ impl Meeting {
     }
 
     /// Adds `count` attendees of a given [`EmployeeCategory`] to the meeting.
+    ///
+    /// ## Example
+    /// ```
+    /// use meeting_cost_tracker::{EmployeeCategory, Meeting};
+    /// let mut meeting = Meeting::new();
+    /// let cat = EmployeeCategory::new("Engineer", 100_000.0).unwrap();
+    /// meeting.add_attendee(&cat, 3);
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// * `category` - The [`EmployeeCategory`] to add.
+    /// * `count` - Number of attendees to add.
+    ///
+    /// # Returns
+    ///
+    /// Nothing.
+    ///
+    /// # See Also
+    /// * [`Meeting::remove_attendee`]
     pub fn add_attendee(&mut self, category: &EmployeeCategory, count: u32) {
         let entry = self
             .attendees
@@ -35,6 +74,27 @@ impl Meeting {
 
     /// Removes up to `count` attendees of the given title from the meeting.
     /// If the resulting count is zero, the attendee entry is removed entirely.
+    ///
+    /// ## Example
+    /// ```
+    /// use meeting_cost_tracker::{EmployeeCategory, Meeting};
+    /// let cat = EmployeeCategory::new("Dev", 90_000.0).unwrap();
+    /// let mut meeting = Meeting::new();
+    /// meeting.add_attendee(&cat, 2);
+    /// meeting.remove_attendee("Dev", 1);
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// * `title` - Title of the attendees to remove.
+    /// * `count` - Number of attendees to remove.
+    ///
+    /// # Returns
+    ///
+    /// Nothing.
+    ///
+    /// # See Also
+    /// * [`Meeting::add_attendee`]
     pub fn remove_attendee(&mut self, title: &str, count: u32) {
         if let Some(entry) = self.attendees.get_mut(title) {
             if entry.1 <= count {
@@ -46,11 +106,56 @@ impl Meeting {
     }
 
     /// Returns an iterator over the attendee list.
+    ///
+    /// The iterator yields the employee title along with a tuple `(salary, count)`.
+    ///
+    /// ## Example
+    /// ```
+    /// use meeting_cost_tracker::{EmployeeCategory, Meeting};
+    /// let cat = EmployeeCategory::new("QA", 80_000.0).unwrap();
+    /// let mut meeting = Meeting::new();
+    /// meeting.add_attendee(&cat, 1);
+    /// for (title, (salary, count)) in meeting.attendees() {
+    ///     println!("{} - {} x ${}", title, count, salary);
+    /// }
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// An iterator over `(title, (salary, count))` entries.
+    ///
+    /// # See Also
+    /// * [`Meeting::add_attendee`]
+    /// * [`Meeting::remove_attendee`]
     pub fn attendees(&self) -> impl Iterator<Item = (&String, &(f64, u32))> {
         self.attendees.iter()
     }
 
-    /// Starts the meeting. Does nothing if already running.
+    /// Starts the meeting timer.
+    ///
+    /// Calling this method while the meeting is already running has no effect.
+    ///
+    /// ## Example
+    /// ```
+    /// use meeting_cost_tracker::Meeting;
+    /// let mut meeting = Meeting::new();
+    /// meeting.start();
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// Nothing.
+    ///
+    /// # See Also
+    /// * [`Meeting::stop`]
     pub fn start(&mut self) {
         if !self.running {
             self.start_time = Some(Instant::now());
@@ -58,7 +163,28 @@ impl Meeting {
         }
     }
 
-    /// Stops the meeting and accumulates elapsed time. Safe to call multiple times.
+    /// Stops the meeting and accumulates elapsed time.
+    ///
+    /// This method is safe to call multiple times.
+    ///
+    /// ## Example
+    /// ```
+    /// use meeting_cost_tracker::Meeting;
+    /// let mut meeting = Meeting::new();
+    /// meeting.start();
+    /// meeting.stop();
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// Nothing.
+    ///
+    /// # See Also
+    /// * [`Meeting::start`]
     pub fn stop(&mut self) {
         if self.running {
             if let Some(start_time) = self.start_time.take() {
@@ -68,7 +194,31 @@ impl Meeting {
         }
     }
 
-    /// Resets the meeting.
+    /// Resets the meeting to its initial state.
+    ///
+    /// This clears all attendees and elapsed time.
+    ///
+    /// ## Example
+    /// ```
+    /// use meeting_cost_tracker::{EmployeeCategory, Meeting};
+    /// let mut meeting = Meeting::new();
+    /// let cat = EmployeeCategory::new("Engineer", 120_000.0).unwrap();
+    /// meeting.add_attendee(&cat, 2);
+    /// meeting.reset();
+    /// assert_eq!(meeting.total_cost(), 0.0);
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// Nothing.
+    ///
+    /// # See Also
+    /// * [`Meeting::start`]
+    /// * [`Meeting::stop`]
     pub fn reset(&mut self) {
         self.attendees.clear();
         self.start_time = None;
@@ -77,12 +227,60 @@ impl Meeting {
     }
 
     /// Returns the total duration the meeting has been active.
+    ///
+    /// ## Example
+    /// ```
+    /// use meeting_cost_tracker::Meeting;
+    /// let mut meeting = Meeting::new();
+    /// meeting.start();
+    /// std::thread::sleep(std::time::Duration::from_millis(10));
+    /// meeting.stop();
+    /// let d = meeting.duration();
+    /// assert!(d.as_millis() > 0);
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// The total duration of the meeting.
+    ///
+    /// # See Also
+    /// * [`Meeting::start`]
+    /// * [`Meeting::stop`]
     #[must_use]
     pub fn duration(&self) -> Duration {
         self.elapsed + self.current_duration()
     }
 
     /// Returns the cost in dollars based on elapsed time and attendee salaries.
+    ///
+    /// ## Example
+    /// ```
+    /// use meeting_cost_tracker::{EmployeeCategory, Meeting};
+    /// let mut meeting = Meeting::new();
+    /// let cat = EmployeeCategory::new("Engineer", 100_000.0).unwrap();
+    /// meeting.add_attendee(&cat, 1);
+    /// meeting.start();
+    /// std::thread::sleep(std::time::Duration::from_millis(10));
+    /// meeting.stop();
+    /// let cost = meeting.total_cost();
+    /// assert!(cost > 0.0);
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// The total cost in dollars.
+    ///
+    /// # See Also
+    /// * [`Meeting::duration`]
+    /// * [`EmployeeCategory::cost_per_millisecond`]
     #[must_use]
     #[allow(clippy::cast_precision_loss)]
     pub fn total_cost(&self) -> f64 {
@@ -97,11 +295,45 @@ impl Meeting {
     }
 
     /// Checks whether the meeting is currently running.
+    ///
+    /// ## Example
+    /// ```
+    /// use meeting_cost_tracker::Meeting;
+    /// let mut meeting = Meeting::new();
+    /// meeting.start();
+    /// assert!(meeting.is_running());
+    /// meeting.stop();
+    /// assert!(!meeting.is_running());
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// `true` if the meeting is running.
+    ///
+    /// # See Also
+    /// * [`Meeting::start`]
+    /// * [`Meeting::stop`]
     #[must_use]
     pub fn is_running(&self) -> bool {
         self.running
     }
 
+    /// Computes the duration since the meeting was started if it is running.
+    ///
+    /// # Arguments
+    ///
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// The current running duration.
+    ///
+    /// # See Also
+    /// * [`Meeting::duration`]
     fn current_duration(&self) -> Duration {
         if self.running {
             self.start_time.map_or(Duration::ZERO, |t| t.elapsed())
@@ -112,7 +344,7 @@ impl Meeting {
 }
 
 impl Default for Meeting {
-        fn default() -> Self {
-            Self::new()
-        }
+    fn default() -> Self {
+        Self::new()
     }
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -21,11 +21,33 @@ pub struct EmployeeCategory {
 }
 
 impl EmployeeCategory {
-    /// Creates a new [`EmployeeCategory`] with validation.
+    /// Creates a new [`EmployeeCategory`] after validating its fields.
     ///
     /// # Errors
     ///
-    /// Returns [`EmployeeCategoryError`] if title is empty or salary is non-positive.
+    /// Returns an [`EmployeeCategoryError`] if `title` is empty or `salary` is not
+    /// greater than zero.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// use meeting_cost_tracker::EmployeeCategory;
+    /// let category = EmployeeCategory::new("Engineer", 120_000.0).unwrap();
+    /// assert_eq!(category.title(), "Engineer");
+    /// ```
+    ///
+    /// # See Also
+    /// * [`EmployeeCategory::title`]
+    /// * [`EmployeeCategory::salary`]
+    ///
+    /// # Arguments
+    ///
+    /// * `title` - Category title.
+    /// * `salary` - Annual salary in dollars.
+    ///
+    /// # Returns
+    ///
+    /// A new [`EmployeeCategory`] on success.
     pub fn new<T: Into<String>>(title: T, salary: f64) -> Result<Self, EmployeeCategoryError> {
         let title = title.into();
         if title.trim().is_empty() {
@@ -38,18 +60,74 @@ impl EmployeeCategory {
     }
 
     /// Returns the title of the employee category.
+    ///
+    /// ## Example
+    /// ```
+    /// use meeting_cost_tracker::EmployeeCategory;
+    /// let cat = EmployeeCategory::new("Designer", 80_000.0).unwrap();
+    /// assert_eq!(cat.title(), "Designer");
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// The title string.
+    ///
+    /// # See Also
+    /// * [`EmployeeCategory::salary`]
     #[must_use]
     pub fn title(&self) -> &str {
         &self.title
     }
 
-    /// Returns the annual salary.
+    /// Returns the annual salary for the category.
+    ///
+    /// ## Example
+    /// ```
+    /// use meeting_cost_tracker::EmployeeCategory;
+    /// let cat = EmployeeCategory::new("Engineer", 100_000.0).unwrap();
+    /// assert_eq!(cat.salary(), 100_000.0);
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// Annual salary in dollars.
+    ///
+    /// # See Also
+    /// * [`EmployeeCategory::title`]
+    /// * [`EmployeeCategory::cost_per_millisecond`]
     #[must_use]
     pub fn salary(&self) -> f64 {
         self.salary
     }
 
-    /// Computes the cost per millisecond.
+    /// Computes the cost in dollars for each millisecond of time.
+    ///
+    /// ## Example
+    /// ```
+    /// use meeting_cost_tracker::EmployeeCategory;
+    /// let cat = EmployeeCategory::new("Analyst", 90_000.0).unwrap();
+    /// let ms = cat.cost_per_millisecond();
+    /// assert!(ms > 0.0);
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// * None
+    ///
+    /// # Returns
+    ///
+    /// The cost per millisecond in dollars.
+    ///
+    /// # See Also
+    /// * [`EmployeeCategory::salary`]
     #[must_use]
     pub fn cost_per_millisecond(&self) -> f64 {
         self.salary / (365.25 * 24.0 * 60.0 * 60.0 * 1000.0)

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,6 +1,6 @@
 use std::fs;
-use std::path::Path;
 use std::io::{self, Write};
+use std::path::Path;
 
 use crate::model::EmployeeCategory;
 use thiserror::Error;
@@ -23,7 +23,27 @@ struct CategoryWrapper {
     categories: Vec<EmployeeCategory>,
 }
 
-/// Loads categories from a TOML file. Returns an empty Vec if the file doesn't exist.
+/// Loads employee categories from a TOML file.
+///
+/// If the file does not exist an empty collection is returned.
+///
+/// ## Example
+/// ```
+/// use std::path::Path;
+/// use meeting_cost_tracker::load_categories;
+/// let categories = load_categories(Path::new("categories.toml")).unwrap();
+/// ```
+///
+/// # Arguments
+///
+/// * `path` - Path to the TOML file.
+///
+/// # Returns
+///
+/// A collection of [`EmployeeCategory`] values.
+///
+/// # See Also
+/// * [`save_categories`]
 pub fn load_categories(path: &Path) -> Result<Vec<EmployeeCategory>, StorageError> {
     if !path.exists() {
         return Ok(vec![]);
@@ -33,7 +53,27 @@ pub fn load_categories(path: &Path) -> Result<Vec<EmployeeCategory>, StorageErro
     Ok(wrapper.categories)
 }
 
-/// Saves categories to a TOML file, overwriting any existing content.
+/// Persists employee categories to a TOML file, overwriting any existing content.
+///
+/// ## Example
+/// ```
+/// use std::path::Path;
+/// use meeting_cost_tracker::{save_categories, EmployeeCategory};
+/// let categories = vec![EmployeeCategory::new("Engineer", 100_000.0).unwrap()];
+/// save_categories(Path::new("categories.toml"), &categories).unwrap();
+/// ```
+///
+/// # Arguments
+///
+/// * `path` - Destination TOML file.
+/// * `categories` - Employee categories to store.
+///
+/// # Returns
+///
+/// Result indicating success or failure.
+///
+/// # See Also
+/// * [`load_categories`]
 pub fn save_categories<P: AsRef<Path>>(
     path: P,
     categories: &[EmployeeCategory],

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -21,7 +21,7 @@ mod tests {
     fn test_meeting_cost_accumulation() {
         let cat = EmployeeCategory::new("Dev", 120_000.0).unwrap();
         let mut meeting = Meeting::new();
-        meeting.add_attendee(cat.clone(), 2);
+        meeting.add_attendee(&cat, 2);
         meeting.start();
         std::thread::sleep(Duration::from_millis(50));
         meeting.stop();
@@ -34,7 +34,7 @@ mod tests {
     fn test_meeting_reset() {
         let cat = EmployeeCategory::new("Analyst", 90_000.0).unwrap();
         let mut meeting = Meeting::new();
-        meeting.add_attendee(cat.clone(), 1);
+        meeting.add_attendee(&cat, 1);
         meeting.start();
         std::thread::sleep(Duration::from_millis(20));
         meeting.stop();
@@ -47,7 +47,7 @@ mod tests {
     fn test_add_and_remove_attendees() {
         let cat = EmployeeCategory::new("QA", 80_000.0).unwrap();
         let mut meeting = Meeting::new();
-        meeting.add_attendee(cat.clone(), 3);
+        meeting.add_attendee(&cat, 3);
         assert_eq!(meeting.attendees().next().unwrap().1 .1, 3);
         meeting.remove_attendee(cat.title(), 2);
         assert_eq!(meeting.attendees().next().unwrap().1 .1, 1);


### PR DESCRIPTION
## Summary
- enhance documentation for the entire library
- add usage examples and cross references
- fix doc examples and tests to borrow `EmployeeCategory`
- add `# Arguments` and `# Returns` sections to all items

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68730376c960832792641aed17a0590d