### PR TITLE
Improve documentation for crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
-# meeting_cost_tracker
-tracks the cost of meetings in real time.
+# Meeting Cost Tracker
+
+`meeting_cost_tracker` provides a small library and optional terminal user
+interface for monitoring the real-time cost of meetings. It calculates cost
+based on the salaries of attendees and the elapsed time of a meeting.
+
+The library is intended for integration into other tools but also ships with a
+TUI binary that demonstrates its capabilities.
+
+## Example
+
+```rust
+use meeting_cost_tracker::{EmployeeCategory, Meeting};
+
+let category = EmployeeCategory::new("Engineer", 120_000.0).unwrap();
+let mut meeting = Meeting::new();
+meeting.add_attendee(&category, 3);
+meeting.start();
+std::thread::sleep(std::time::Duration::from_secs(1));
+meeting.stop();
+println!("Cost: ${:.2}", meeting.total_cost());
+```
+
+Running the provided binary gives an interactive interface for adding employee
+categories and tracking a meeting live:
+
+```console
+$ cargo run --release --bin meeting_cost_tracker
+```
+
+## See Also
+
+- [`Meeting`](src/meeting.rs) – core meeting logic.
+- [`EmployeeCategory`](src/model.rs) – employee salary representation.
+- [`load_categories`](src/storage.rs) – persistence helpers.
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,9 @@ mod meeting;
 mod model;
 mod storage;
 
+/// Core meeting functionality including timers and cost computation.
 pub use meeting::Meeting;
+/// Represents an employee salary category.
 pub use model::EmployeeCategory;
+/// Persistence helpers for reading and writing categories as TOML.
 pub use storage::{load_categories, save_categories};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+//! Interactive terminal application for tracking meeting costs.
 // main.rs
 
 use std::{error::Error, path::PathBuf, time::Duration};
@@ -14,14 +15,30 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
 use ratatui::Terminal;
 
+/// UI modes controlling user interaction.
 enum Mode {
+    /// Normal viewing mode where meeting stats are displayed.
     View,
+    /// Mode for creating a new [`EmployeeCategory`].
     AddCategory,
+    /// Mode for deleting an existing [`EmployeeCategory`].
     DeleteCategory,
+    /// Mode for adding attendees to the [`Meeting`].
     AddAttendee,
+    /// Mode for removing attendees from the [`Meeting`].
     RemoveAttendee,
 }
 
+/// Entry point for the interactive TUI application.
+///
+/// This function initializes the terminal, loads persisted employee
+/// categories, and enters the main event loop. On exit, updated categories
+/// are saved back to disk.
+///
+/// # Errors
+///
+/// Returns an error if terminal initialization fails or if the category
+/// database cannot be loaded or saved.
 fn main() -> Result<(), Box<dyn Error>> {
     let db_path = PathBuf::from("categories.toml");
     let mut categories = load_categories(&db_path)?;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -18,6 +18,11 @@ pub enum StorageError {
     TomlWrite(#[from] toml::ser::Error),
 }
 
+/// Internal helper struct used for serializing and deserializing the collection
+/// of [`EmployeeCategory`] values.
+///
+/// The wrapper is not exposed publicly but simplifies the structure of the TOML
+/// file on disk.
 #[derive(serde::Serialize, serde::Deserialize)]
 struct CategoryWrapper {
     categories: Vec<EmployeeCategory>,
@@ -49,6 +54,10 @@ struct CategoryWrapper {
 ///
 /// # See Also
 /// * [`save_categories`]
+///
+/// # Panics
+///
+/// This function does not panic.
 pub fn load_categories(path: &Path) -> Result<Vec<EmployeeCategory>, StorageError> {
     if !path.exists() {
         return Ok(vec![]);
@@ -84,6 +93,10 @@ pub fn load_categories(path: &Path) -> Result<Vec<EmployeeCategory>, StorageErro
 ///
 /// # See Also
 /// * [`load_categories`]
+///
+/// # Panics
+///
+/// This function does not panic.
 pub fn save_categories<P: AsRef<Path>>(
     path: P,
     categories: &[EmployeeCategory],


### PR DESCRIPTION
## Summary
- add crate usage examples to README
- document module reexports in `lib.rs`
- add documentation for `Mode` enum and `main` function
- document storage internals and panic behavior

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68730e9411748327ad8a01643d7f17a8