### PR TITLE
Add mct binary alias

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/Andrewsimsd/meeting_cost_tracker"
 readme = "README.md"
 keywords = ["tui", "ratatui", "meeting", "salary", "tracker"]
 categories = ["command-line-utilities", "visualization"]
+default-run = "mct"
 
 [dependencies]
 ratatui = "0.29"
@@ -23,7 +24,7 @@ assert_cmd = "2.0"
 predicates = "3.1"
 
 [[bin]]
-name = "meeting_cost_tracker"
+name = "mct"
 path = "src/main.rs"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ Running the provided binary gives an interactive interface for adding employee
 categories and tracking a meeting live:
 
 ```console
-$ cargo run --release --bin meeting_cost_tracker
+$ cargo run --release --bin mct
 ```
+
+After installing the crate with `cargo install --path .`, you can run the TUI
+directly using the `mct` command.
 
 ## See Also
 


### PR DESCRIPTION
## Summary
- rename binary to `mct` and update package default run
- document the new command name and how to run it

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6873190b14a08327a7e5a4273e2c4fcf