### PR TITLE
Fix release binary path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         shell: bash
         run: |
           mkdir dist
-          cp target/${{ matrix.target }}/release/meeting_cost_tracker${{ matrix.ext }} dist/meeting_cost_tracker-${{ matrix.target }}${{ matrix.ext }}
+          cp target/${{ matrix.target }}/release/mct${{ matrix.ext }} dist/meeting_cost_tracker-${{ matrix.target }}${{ matrix.ext }}
         # Only run zip if not Windows
       - name: Zip binary (non-Windows)
         if: matrix.os != 'windows-latest'


### PR DESCRIPTION
## Summary
- fix release workflow to use the actual binary name `mct`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68732683f0788327b4ab2405460d0ab7