### PR TITLE
Refactor attendee map and salary types

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ TUI binary that demonstrates its capabilities.
 ```rust
 use meeting_cost_tracker::{EmployeeCategory, Meeting};
 
-let category = EmployeeCategory::new("Engineer", 120_000.0).unwrap();
+let category = EmployeeCategory::new("Engineer", 120_000).unwrap();
 let mut meeting = Meeting::new();
 meeting.add_attendee(&category, 3);
 meeting.start();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! ```rust
 //! use meeting_cost_tracker::{EmployeeCategory, Meeting};
 //!
-//! let category = EmployeeCategory::new("Engineer", 120_000.0).unwrap();
+//! let category = EmployeeCategory::new("Engineer", 120_000).unwrap();
 //! let mut meeting = Meeting::new();
 //! meeting.add_attendee(&category, 3);
 //! meeting.start();

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
             let meeting_list: Vec<Line> = meeting
                 .attendees()
-                .map(|(title, (_, count))| Line::from(Span::raw(format!("{title} x {count}"))))
+                .map(|(cat, count)| Line::from(Span::raw(format!("{} x {}", cat.title(), count))))
                 .collect();
             let meeting_widget = Paragraph::new(meeting_list)
                 .block(Block::default().borders(Borders::ALL).title("Current Meeting"));
@@ -178,7 +178,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                             match mode {
                                 Mode::AddCategory => {
                                     if let Some((title, salary_str)) = input_text.split_once(':') {
-                                        if let Ok(salary) = salary_str.trim().parse::<f64>() {
+                                        if let Ok(salary) = salary_str.trim().parse::<u64>() {
                                             if let Ok(cat) =
                                                 EmployeeCategory::new(title.trim(), salary)
                                             {

--- a/src/model.rs
+++ b/src/model.rs
@@ -14,10 +14,10 @@ pub enum EmployeeCategoryError {
 }
 
 /// Represents an employee category (e.g., Engineer, Manager) with a yearly salary.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct EmployeeCategory {
     title: String,
-    salary: f64,
+    salary: u64,
 }
 
 impl EmployeeCategory {
@@ -32,7 +32,7 @@ impl EmployeeCategory {
     ///
     /// ```
     /// use meeting_cost_tracker::EmployeeCategory;
-    /// let category = EmployeeCategory::new("Engineer", 120_000.0).unwrap();
+    /// let category = EmployeeCategory::new("Engineer", 120_000).unwrap();
     /// assert_eq!(category.title(), "Engineer");
     /// ```
     ///
@@ -48,12 +48,12 @@ impl EmployeeCategory {
     /// # Returns
     ///
     /// A new [`EmployeeCategory`] on success.
-    pub fn new<T: Into<String>>(title: T, salary: f64) -> Result<Self, EmployeeCategoryError> {
+    pub fn new<T: Into<String>>(title: T, salary: u64) -> Result<Self, EmployeeCategoryError> {
         let title = title.into();
         if title.trim().is_empty() {
             return Err(EmployeeCategoryError::EmptyTitle);
         }
-        if salary <= 0.0 {
+        if salary == 0 {
             return Err(EmployeeCategoryError::InvalidSalary);
         }
         Ok(Self { title, salary })
@@ -64,7 +64,7 @@ impl EmployeeCategory {
     /// ## Example
     /// ```
     /// use meeting_cost_tracker::EmployeeCategory;
-    /// let cat = EmployeeCategory::new("Designer", 80_000.0).unwrap();
+    /// let cat = EmployeeCategory::new("Designer", 80_000).unwrap();
     /// assert_eq!(cat.title(), "Designer");
     /// ```
     ///
@@ -88,8 +88,8 @@ impl EmployeeCategory {
     /// ## Example
     /// ```
     /// use meeting_cost_tracker::EmployeeCategory;
-    /// let cat = EmployeeCategory::new("Engineer", 100_000.0).unwrap();
-    /// assert_eq!(cat.salary(), 100_000.0);
+    /// let cat = EmployeeCategory::new("Engineer", 100_000).unwrap();
+    /// assert_eq!(cat.salary(), 100_000);
     /// ```
     ///
     /// # Arguments
@@ -104,7 +104,7 @@ impl EmployeeCategory {
     /// * [`EmployeeCategory::title`]
     /// * [`EmployeeCategory::cost_per_millisecond`]
     #[must_use]
-    pub fn salary(&self) -> f64 {
+    pub fn salary(&self) -> u64 {
         self.salary
     }
 
@@ -113,7 +113,7 @@ impl EmployeeCategory {
     /// ## Example
     /// ```
     /// use meeting_cost_tracker::EmployeeCategory;
-    /// let cat = EmployeeCategory::new("Analyst", 90_000.0).unwrap();
+    /// let cat = EmployeeCategory::new("Analyst", 90_000).unwrap();
     /// let ms = cat.cost_per_millisecond();
     /// assert!(ms > 0.0);
     /// ```
@@ -130,6 +130,6 @@ impl EmployeeCategory {
     /// * [`EmployeeCategory::salary`]
     #[must_use]
     pub fn cost_per_millisecond(&self) -> f64 {
-        self.salary / (365.25 * 24.0 * 60.0 * 60.0 * 1000.0)
+        self.salary as f64 / (365.25 * 24.0 * 60.0 * 60.0 * 1000.0)
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -73,7 +73,7 @@ pub fn load_categories(path: &Path) -> Result<Vec<EmployeeCategory>, StorageErro
 /// ```
 /// use std::path::Path;
 /// use meeting_cost_tracker::{save_categories, EmployeeCategory};
-/// let categories = vec![EmployeeCategory::new("Engineer", 100_000.0).unwrap()];
+/// let categories = vec![EmployeeCategory::new("Engineer", 100_000).unwrap()];
 /// save_categories(Path::new("categories.toml"), &categories).unwrap();
 /// ```
 ///

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,19 +7,19 @@ mod tests {
 
     #[test]
     fn test_employee_category_creation() {
-        let valid = EmployeeCategory::new("Engineer", 100_000.0);
+        let valid = EmployeeCategory::new("Engineer", 100_000);
         assert!(valid.is_ok());
 
-        let empty_title = EmployeeCategory::new("", 100_000.0);
+        let empty_title = EmployeeCategory::new("", 100_000);
         assert!(empty_title.is_err());
 
-        let zero_salary = EmployeeCategory::new("Manager", 0.0);
+        let zero_salary = EmployeeCategory::new("Manager", 0);
         assert!(zero_salary.is_err());
     }
 
     #[test]
     fn test_meeting_cost_accumulation() {
-        let cat = EmployeeCategory::new("Dev", 120_000.0).unwrap();
+        let cat = EmployeeCategory::new("Dev", 120_000).unwrap();
         let mut meeting = Meeting::new();
         meeting.add_attendee(&cat, 2);
         meeting.start();
@@ -33,7 +33,7 @@ mod tests {
     #[test]
     #[allow(clippy::float_cmp)]
     fn test_meeting_reset() {
-        let cat = EmployeeCategory::new("Analyst", 90_000.0).unwrap();
+        let cat = EmployeeCategory::new("Analyst", 90_000).unwrap();
         let mut meeting = Meeting::new();
         meeting.add_attendee(&cat, 1);
         meeting.start();
@@ -46,12 +46,12 @@ mod tests {
 
     #[test]
     fn test_add_and_remove_attendees() {
-        let cat = EmployeeCategory::new("QA", 80_000.0).unwrap();
+        let cat = EmployeeCategory::new("QA", 80_000).unwrap();
         let mut meeting = Meeting::new();
         meeting.add_attendee(&cat, 3);
-        assert_eq!(meeting.attendees().next().unwrap().1 .1, 3);
+        assert_eq!(*meeting.attendees().next().unwrap().1, 3);
         meeting.remove_attendee(cat.title(), 2);
-        assert_eq!(meeting.attendees().next().unwrap().1 .1, 1);
+        assert_eq!(*meeting.attendees().next().unwrap().1, 1);
         meeting.remove_attendee(cat.title(), 1);
         assert!(meeting.attendees().next().is_none());
     }
@@ -60,8 +60,8 @@ mod tests {
     fn test_persistence_round_trip() {
         let path = PathBuf::from("test_categories.toml");
         let original = vec![
-            EmployeeCategory::new("A", 10_000.0).unwrap(),
-            EmployeeCategory::new("B", 20_000.0).unwrap(),
+            EmployeeCategory::new("A", 10_000).unwrap(),
+            EmployeeCategory::new("B", 20_000).unwrap(),
         ];
         save_categories(&path, &original).unwrap();
         let loaded = load_categories(&path).unwrap();


### PR DESCRIPTION
## Summary
- replace float salaries with `u64` so `EmployeeCategory` can be used as a `HashMap` key
- store meeting attendees as `HashMap<EmployeeCategory, u32>`
- update examples, tests and TUI parsing logic

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6873d2f2d80083279304b4c3064c4ff3