### PR TITLE
Fix cost calc and adjust UI layout

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,8 +68,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                     Constraint::Length(3),  // title
                     Constraint::Length(1),  // status line
                     Constraint::Length(3),  // cost display
-                    Constraint::Length(3),  // input/help
                     Constraint::Min(1),     // lists
+                    Constraint::Length(3),  // input/help
                 ])
                 .split(size);
 
@@ -109,12 +109,12 @@ fn main() -> Result<(), Box<dyn Error>> {
                 Mode::AddCategory => {
                     let input_widget = Paragraph::new(input_text.as_str())
                         .block(Block::default().title("Enter: Title:Salary").borders(Borders::ALL));
-                    f.render_widget(input_widget, chunks[3]);
+                    f.render_widget(input_widget, chunks[4]);
                 }
                 Mode::DeleteCategory => {
                     let input_widget = Paragraph::new(input_text.as_str())
                         .block(Block::default().title("Enter title to delete").borders(Borders::ALL));
-                    f.render_widget(input_widget, chunks[3]);
+                    f.render_widget(input_widget, chunks[4]);
                 }
                 Mode::View => {
                     let help = Paragraph::new(Line::from(vec![
@@ -124,7 +124,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         ),
                     ]))
                     .block(Block::default().borders(Borders::ALL).title("Controls"));
-                    f.render_widget(help, chunks[3]);
+                    f.render_widget(help, chunks[4]);
                 }
                 Mode::AddAttendee => {
                     let input_widget = Paragraph::new(input_text.as_str())
@@ -133,19 +133,19 @@ fn main() -> Result<(), Box<dyn Error>> {
                                 .title("Enter: Title[:Count]")
                                 .borders(Borders::ALL),
                         );
-                    f.render_widget(input_widget, chunks[3]);
+                    f.render_widget(input_widget, chunks[4]);
                 }
                 Mode::RemoveAttendee => {
                     let input_widget = Paragraph::new(input_text.as_str())
                         .block(Block::default().title("Enter: Title:Count to remove").borders(Borders::ALL));
-                    f.render_widget(input_widget, chunks[3]);
+                    f.render_widget(input_widget, chunks[4]);
                 }
             }
 
             let lists = Layout::default()
                 .direction(Direction::Horizontal)
                 .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-                .split(chunks[4]);
+                .split(chunks[3]);
 
             let category_list: Vec<Line> = categories
                 .iter()
@@ -232,7 +232,9 @@ fn main() -> Result<(), Box<dyn Error>> {
                                         }
                                         None => (input_text.trim(), 1),
                                     };
-                                    if let Some(cat) = categories.iter().find(|c| c.title() == title) {
+                                    if let Some(cat) =
+                                        categories.iter().find(|c| c.title() == title)
+                                    {
                                         meeting.add_attendee(cat, count);
                                     }
                                 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -131,7 +131,8 @@ impl EmployeeCategory {
     #[must_use]
     #[allow(clippy::cast_precision_loss)]
     pub fn cost_per_millisecond(&self) -> f64 {
-        // 2000 work hours per year, 60 mins per hours, 60 secs per hour, 1000 ms per second.
-        (self.salary / (2000 * 60 * 60 * 1000)) as f64
+        // 2000 work hours per year, 60 mins per hour, 60 secs per minute, 1000 ms per second.
+        let yearly_ms = 2000.0 * 60.0 * 60.0 * 1000.0;
+        self.salary as f64 / yearly_ms
     }
 }


### PR DESCRIPTION
## Summary
- fix floating point division in `EmployeeCategory::cost_per_millisecond`
- move controls widget below the category and meeting lists

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6873dd39a1d48327aed745308accfbdc