### PR TITLE
Add reset key to meeting TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ $ cargo run --release --bin mct
 After installing the crate with `cargo install --path .`, you can run the TUI
 directly using the `mct` command.
 
+The interface responds to several keyboard shortcuts:
+`s` to start, `t` to stop, `c` to reset the meeting, `a` to add a category,
+`d` to delete a category, `e` to add attendees, `r` to remove attendees, and
+`q` to quit.
+
 ## See Also
 
 - [`Meeting`](src/meeting.rs) – core meeting logic.

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,7 +119,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 Mode::View => {
                     let help = Paragraph::new(Line::from(vec![
                         Span::styled(
-                            "[s] Start  [t] Stop  [a] Add Category  [d] Delete Category  [e] Add Employee  [r] Remove Employee  [q] Quit",
+                            "[s] Start  [t] Stop  [c] Reset  [a] Add Category  [d] Delete Category  [e] Add Employee  [r] Remove Employee  [q] Quit",
                             Style::default().fg(Color::Yellow),
                         ),
                     ]))
@@ -185,6 +185,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         KeyCode::Char('q') => break,
                         KeyCode::Char('s') => meeting.start(),
                         KeyCode::Char('t') => meeting.stop(),
+                        KeyCode::Char('c') => meeting.reset(),
                         KeyCode::Char('a') => {
                             input_text.clear();
                             mode = Mode::AddCategory;


### PR DESCRIPTION
## Summary
- update TUI controls to include `c` key for resetting the current meeting
- document available keyboard shortcuts in the README

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6873fbde8b6483279e6d221d565725fa