### PR TITLE
Add salary toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ directly using the `mct` command.
 
 The interface responds to several keyboard shortcuts:
 `s` to start, `t` to stop, `c` to reset the meeting, `a` to add a category,
-`d` to delete a category, `e` to add attendees, `r` to remove attendees, and
-`q` to quit.
+`d` to delete a category, `e` to add attendees, `r` to remove attendees,
+`p` to toggle salary visibility, and `q` to quit.
 
 ## See Also
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut mode = Mode::View;
     let mut input_text = String::new();
+    let mut show_salaries = false;
 
     enable_raw_mode()?;
     let mut stdout = std::io::stdout();
@@ -119,7 +120,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 Mode::View => {
                     let help = Paragraph::new(Line::from(vec![
                         Span::styled(
-                            "[s] Start  [t] Stop  [c] Reset  [a] Add Category  [d] Delete Category  [e] Add Employee  [r] Remove Employee  [q] Quit",
+                            "[s] Start  [t] Stop  [c] Reset  [a] Add Category  [d] Delete Category  [e] Add Employee  [r] Remove Employee  [p] Toggle Salaries  [q] Quit",
                             Style::default().fg(Color::Yellow),
                         ),
                     ]))
@@ -150,10 +151,12 @@ fn main() -> Result<(), Box<dyn Error>> {
             let category_list: Vec<Line> = categories
                 .iter()
                 .map(|c| {
-                    Line::from(Span::styled(
-                        format!("{}: ${}", c.title(), c.salary()),
-                        Style::default().fg(Color::Cyan),
-                    ))
+                    let text = if show_salaries {
+                        format!("{}: ${}", c.title(), c.salary())
+                    } else {
+                        c.title().to_string()
+                    };
+                    Line::from(Span::styled(text, Style::default().fg(Color::Cyan)))
                 })
                 .collect();
             let list_widget = Paragraph::new(category_list)
@@ -202,6 +205,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                             input_text.clear();
                             mode = Mode::RemoveAttendee;
                         }
+                        KeyCode::Char('p') => show_salaries = !show_salaries,
                         _ => {}
                     },
                     Mode::AddCategory


### PR DESCRIPTION
## Summary
- hide salaries by default in the TUI
- allow toggling salary visibility with `p`
- document new shortcut in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6873fd7d212083278f28950c55a032a1