### PR TITLE
Improve TUI cost output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "figlet-rs"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4742a071cd9694fc86f9fa1a08fa3e53d40cc899d7ee532295da2d085639fbc5"
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +415,7 @@ version = "1.0.0"
 dependencies = [
  "assert_cmd",
  "crossterm 0.29.0",
+ "figlet-rs",
  "predicates",
  "ratatui",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ crossterm = "0.29.0"
 serde = { version = "1", features = ["derive"] }
 toml = "0.9.2"
 thiserror = "2.0.12"
+figlet-rs = "0.1.5"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use ratatui::layout::{Alignment, Constraint, Direction, Layout};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
+use figlet_rs::FIGfont;
 use ratatui::Terminal;
 
 /// UI modes controlling user interaction.
@@ -49,6 +50,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut mode = Mode::View;
     let mut input_text = String::new();
     let mut show_salaries = false;
+    let font = FIGfont::standard().unwrap();
 
     enable_raw_mode()?;
     let mut stdout = std::io::stdout();
@@ -68,7 +70,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .constraints([
                     Constraint::Length(3),  // title
                     Constraint::Length(1),  // status line
-                    Constraint::Length(3),  // cost display
+                    Constraint::Length(8),  // cost display
                     Constraint::Min(1),     // lists
                     Constraint::Length(3),  // input/help
                 ])
@@ -97,13 +99,15 @@ fn main() -> Result<(), Box<dyn Error>> {
             ]));
             f.render_widget(status, chunks[1]);
 
-            let cost_widget = Paragraph::new(Line::from(Span::styled(
-                format!("${cost_display:.2}"),
-                Style::default()
-                    .fg(Color::Green)
-                    .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
-            )))
-            .alignment(Alignment::Center);
+            let figure = font
+                .convert(&format!("${cost_display:.2}"))
+                .unwrap_or_else(|| font.convert("0").unwrap());
+            let lines: Vec<Line> = figure
+                .to_string()
+                .lines()
+                .map(|l| Line::from(Span::styled(l.to_string(), Style::default().fg(Color::Green))))
+                .collect();
+            let cost_widget = Paragraph::new(lines).alignment(Alignment::Center);
             f.render_widget(cost_widget, chunks[2]);
 
             match mode {


### PR DESCRIPTION
## Summary
- add `figlet-rs` to render big ASCII text
- show meeting cost in larger font in the TUI

## Testing
- `cargo check`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_68741aaf3cf08327a8850e70d57eccea