### PR TITLE
Fix double key input on Windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,9 @@
 
 use std::{error::Error, path::PathBuf, time::Duration};
 
-use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode};
+use crossterm::event::{
+    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind,
+};
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
 };
@@ -289,17 +291,19 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         if event::poll(timeout)? {
             if let Event::Key(key_event) = event::read()? {
-                if matches!(mode, Mode::View) && matches!(key_event.code, KeyCode::Char('q')) {
-                    break;
+                if key_event.kind == KeyEventKind::Press {
+                    if matches!(mode, Mode::View) && matches!(key_event.code, KeyCode::Char('q')) {
+                        break;
+                    }
+                    process_key(
+                        key_event,
+                        &mut mode,
+                        &mut input_text,
+                        &mut show_salaries,
+                        &mut categories,
+                        &mut meeting,
+                    );
                 }
-                process_key(
-                    key_event,
-                    &mut mode,
-                    &mut input_text,
-                    &mut show_salaries,
-                    &mut categories,
-                    &mut meeting,
-                );
             }
         }
 


### PR DESCRIPTION
## Summary
- prevent processing KeyEvent release events by filtering for `KeyEventKind::Press`
- import `KeyEventKind` for event handling

## Testing
- `cargo fmt --all`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68750e9badc88327b1e9f8b9c853dd7e