### PR TITLE
Add attendee persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,13 @@ Keyboard shortcuts:
 - **e** – add attendees
 - **r** – remove attendees
 - **w** – save attendees to a file
-- **l** – load attendees from a file
+- **l** – load attendees from a file (opens file picker)
 - **p** – toggle salary visibility
 - **q** – quit
 
 Categories are persisted to `data/categories.toml` next to the executable.
-Attendee lists can be saved and loaded from the same directory using the **w** and **l** keys.
+Attendee lists can be saved and loaded from the same directory using the **w** key.
+Press **l** to open a file picker showing available attendee lists in that directory.
 
 ## See Also
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Keyboard shortcuts:
 - **p** – toggle salary visibility
 - **q** – quit
 
-Categories are persisted to `categories.toml` in the current directory.
-Attendee lists can be saved and loaded from custom TOML files using the **w** and **l** keys.
+Categories are persisted to `data/categories.toml` next to the executable.
+Attendee lists can be saved and loaded from the same directory using the **w** and **l** keys.
 
 ## See Also
 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,13 @@ Keyboard shortcuts:
 - **d** – delete an existing category
 - **e** – add attendees
 - **r** – remove attendees
+- **w** – save attendees to a file
+- **l** – load attendees from a file
 - **p** – toggle salary visibility
 - **q** – quit
 
 Categories are persisted to `categories.toml` in the current directory.
+Attendee lists can be saved and loaded from custom TOML files using the **w** and **l** keys.
 
 ## See Also
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,4 +28,4 @@ pub use meeting::Meeting;
 /// Represents an employee salary category.
 pub use model::EmployeeCategory;
 /// Persistence helpers for reading and writing categories as TOML.
-pub use storage::{load_categories, save_categories};
+pub use storage::{load_attendees, load_categories, save_attendees, save_categories, AttendeeInfo};

--- a/src/meeting.rs
+++ b/src/meeting.rs
@@ -237,6 +237,11 @@ impl Meeting {
         self.running = false;
     }
 
+    /// Removes all attendees without modifying timing information.
+    pub fn clear_attendees(&mut self) {
+        self.attendees.clear();
+    }
+
     /// Returns the total duration the meeting has been active.
     ///
     /// ## Example

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -3,7 +3,10 @@ mod tests {
     use std::path::PathBuf;
     use std::time::Duration;
 
-    use meeting_cost_tracker::{load_categories, save_categories, EmployeeCategory, Meeting};
+    use meeting_cost_tracker::{
+        load_attendees, load_categories, save_attendees, save_categories, AttendeeInfo,
+        EmployeeCategory, Meeting,
+    };
 
     #[test]
     fn test_employee_category_creation() {
@@ -67,5 +70,17 @@ mod tests {
         let loaded = load_categories(&path).unwrap();
         assert_eq!(original, loaded);
         std::fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn test_attendee_save_load() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let attendees = vec![AttendeeInfo {
+            title: "Dev".into(),
+            count: 2,
+        }];
+        save_attendees(tmp.path(), &attendees).unwrap();
+        let loaded = load_attendees(tmp.path()).unwrap();
+        assert_eq!(loaded, attendees);
     }
 }


### PR DESCRIPTION
## Summary
- allow attendee info to be saved and loaded from TOML
- expose attendee persistence in the public API
- clear attendees without affecting timing
- add TUI modes for saving/loading attendee lists
- document new keyboard shortcuts
- test new attendee persistence functionality

## Testing
- `cargo test -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_68744af69af883279811c2d38b4e44a6