### PR TITLE
Toggle meeting start and stop with 's' key

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,7 @@ fn render_ui(
             Mode::View => {
                 let help = Paragraph::new(Line::from(vec![
                     Span::styled(
-                        "[s] Start  [t] Stop  [c] Reset  [a] Add Category  [d] Delete Category  [e] Add Employee  [r] Remove Employee  [w] Save Attendees  [l] Load Attendees  [p] Toggle Salaries [q] Quit",
+                        "[s] Start/Stop  [t] Stop  [c] Reset  [a] Add Category  [d] Delete Category  [e] Add Employee  [r] Remove Employee  [w] Save Attendees  [l] Load Attendees  [p] Toggle Salaries [q] Quit",
                         Style::default().fg(Color::Yellow),
                     ),
                 ]))
@@ -252,7 +252,13 @@ fn process_key(
     match *mode {
         Mode::View => match key_event.code {
             KeyCode::Char('q') => *mode = Mode::View, // handled in loop
-            KeyCode::Char('s') => meeting.start(),
+            KeyCode::Char('s') => {
+                if meeting.is_running() {
+                    meeting.stop();
+                } else {
+                    meeting.start();
+                }
+            }
             KeyCode::Char('t') => meeting.stop(),
             KeyCode::Char('c') => meeting.reset(),
             KeyCode::Char('a') => {


### PR DESCRIPTION
## Summary
- allow `s` key to toggle between starting and stopping the meeting
- show this new behavior in the on-screen help

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687720db127c83278657e541ab32b176