### PR TITLE
Improve meeting logic and tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -521,7 +521,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         let timeout = tick_rate
             .checked_sub(last_tick.elapsed())
-            .unwrap_or_else(|| Duration::from_secs(0));
+            .unwrap_or(Duration::ZERO);
 
         if event::poll(timeout)? {
             if let Event::Key(key_event) = event::read()? {
@@ -559,4 +559,23 @@ fn main() -> Result<(), Box<dyn Error>> {
     save_categories(&db_path, &categories)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duration_formatting() {
+        assert_eq!(format_duration(Duration::from_secs(0)), "00:00:00");
+        assert_eq!(format_duration(Duration::from_secs(3661)), "01:01:01");
+    }
+
+    #[test]
+    fn centered_rect_respects_size() {
+        let area = Rect::new(0, 0, 100, 100);
+        let popup = centered_rect(50, 50, area);
+        assert_eq!(popup.width, 50);
+        assert_eq!(popup.height, 50);
+    }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -83,4 +83,21 @@ mod tests {
         let loaded = load_attendees(tmp.path()).unwrap();
         assert_eq!(loaded, attendees);
     }
+
+    #[test]
+    fn test_clear_attendees() {
+        let cat = EmployeeCategory::new("Ops", 70_000).unwrap();
+        let mut meeting = Meeting::new();
+        meeting.add_attendee(&cat, 1);
+        meeting.clear_attendees();
+        assert_eq!(meeting.attendees().count(), 0);
+    }
+
+    #[test]
+    fn test_attendee_count_helper() {
+        let cat = EmployeeCategory::new("Dev", 60_000).unwrap();
+        let mut meeting = Meeting::new();
+        meeting.add_attendee(&cat, 4);
+        assert_eq!(meeting.attendee_count(cat.title()), Some(4));
+    }
 }


### PR DESCRIPTION
## Summary
- refactor `Attendee` to be cloneable and provide a constructor
- expose new `attendee_count` helper
- clarify timeout logic
- add tests for helper functions and additional meeting behaviour

## Testing
- `cargo test --quiet` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68772d1754688327b94327fb355105c2